### PR TITLE
Complete repository rename validation cleanup

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -18,7 +18,7 @@ development:
 
 authors:
   Diogo Ribeiro:
-    href: "https://github.com/Diogoribeiro7"
+    href: "https://github.com/DiogoRibeiro7"
 
 navbar:
   structure:

--- a/tracker.json
+++ b/tracker.json
@@ -5,7 +5,7 @@
     {
       "title": "chore: complete repository rename validation to effectbridge",
       "description": "Ensure no stale references to the old repository/package identity remain.",
-      "status": "in_progress",
+      "status": "completed",
       "priority": "high",
       "labels": ["maintenance", "documentation"]
     },


### PR DESCRIPTION
## Summary
- mark rename-validation tracker task as completed
- normalize GitHub username casing in pkgdown author link

## Validation
- repo scan shows no active unconfoundedr/unconfoudedr references (except checklist text in ISSUE_BACKLOG)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completed repository rename validation to `effectbridge` with no stale references remaining. Normalized the GitHub author link casing in `_pkgdown.yml` and marked the tracker task as `completed` in `tracker.json`.

<sup>Written for commit 35bb6d89261df02b5165925bc9e440f2a081ba05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

