### PR TITLE
Fix test artifact hygiene for plotting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ check/
 inst/doc/
 vignettes/*.html
 Rplots.pdf
+tests/testthat/Rplots.pdf
+tests/testthat/*.pdf
 
 # R session/user files
 .Rhistory

--- a/tests/testthat/helper-graphics.R
+++ b/tests/testthat/helper-graphics.R
@@ -1,0 +1,27 @@
+# Route graphics output to a temp directory to avoid creating tracked artifacts
+# such as tests/testthat/Rplots.pdf during automated test runs.
+with_plot_sandbox <- function(code) {
+  old_wd <- getwd()
+  sandbox_dir <- tempfile("plot-sandbox-")
+  dir.create(sandbox_dir)
+  setwd(sandbox_dir)
+
+  on.exit({
+    setwd(old_wd)
+    unlink(sandbox_dir, recursive = TRUE, force = TRUE)
+  }, add = TRUE)
+
+  # Ensure a graphics device is explicitly open in the sandbox.
+  plot_path <- tempfile("plot-device-", tmpdir = sandbox_dir, fileext = ".pdf")
+  grDevices::pdf(plot_path)
+  dev_id <- grDevices::dev.cur()
+
+  on.exit({
+    open_devs <- grDevices::dev.list()
+    if (!is.null(open_devs) && dev_id %in% open_devs) {
+      grDevices::dev.off(which = dev_id)
+    }
+  }, add = TRUE)
+
+  force(code)
+}

--- a/tests/testthat/test-methods-plotting.R
+++ b/tests/testthat/test-methods-plotting.R
@@ -135,7 +135,7 @@ test_that("plot effects method runs without error", {
     seed = 505
   )
 
-  expect_no_error(plot(result, type = "effects"))
+  expect_no_error(with_plot_sandbox(plot(result, type = "effects")))
 })
 
 test_that("plot overlap method runs without error", {
@@ -153,7 +153,7 @@ test_that("plot overlap method runs without error", {
     seed = 506
   )
 
-  expect_no_error(plot(result, type = "overlap"))
+  expect_no_error(with_plot_sandbox(plot(result, type = "overlap")))
 })
 
 test_that("plot balance method runs without error", {
@@ -171,7 +171,7 @@ test_that("plot balance method runs without error", {
     seed = 507
   )
 
-  expect_no_error(plot(result, type = "balance"))
+  expect_no_error(with_plot_sandbox(plot(result, type = "balance")))
 })
 
 test_that("plot bootstrap method runs without error", {
@@ -190,7 +190,7 @@ test_that("plot bootstrap method runs without error", {
     seed = 508
   )
 
-  expect_no_error(plot(result, type = "bootstrap"))
+  expect_no_error(with_plot_sandbox(plot(result, type = "bootstrap")))
 })
 
 test_that("plot bootstrap handles non-bootstrap inference gracefully", {
@@ -208,7 +208,7 @@ test_that("plot bootstrap handles non-bootstrap inference gracefully", {
     seed = 509
   )
 
-  expect_output(plot(result, type = "bootstrap"), "not available")
+  expect_output(with_plot_sandbox(plot(result, type = "bootstrap")), "not available")
 })
 
 test_that("plot weights handles no-transport case gracefully", {
@@ -227,5 +227,5 @@ test_that("plot weights handles no-transport case gracefully", {
     seed = 510
   )
 
-  expect_output(plot(result, type = "weights"), "No transport")
+  expect_output(with_plot_sandbox(plot(result, type = "weights")), "No transport")
 })


### PR DESCRIPTION
## Summary
- add plotting test sandbox helper to route graphics output to temp directories
- update plotting tests to run through sandboxed device context
- ignore test-generated PDF artifacts (`tests/testthat/Rplots.pdf`, `tests/testthat/*.pdf`)

## Validation
- ran: `Rscript -e "devtools::test(filter='methods-plotting')"`
- confirmed no `Rplots.pdf` or other pdf artifacts remain under repo root or `tests/testthat`

Closes #29


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes all plotting output during tests to a temp sandbox so no PDFs are written to the repo. Fixes #29.

- **Bug Fixes**
  - Added `with_plot_sandbox()` helper to open a PDF device in a temp dir and clean up devices/files.
  - Wrapped plotting tests with the helper to contain graphics output.
  - Ignored `tests/testthat/Rplots.pdf` and `tests/testthat/*.pdf` in `.gitignore`.

<sup>Written for commit 0115428df2f0324e190cc97c94cb3a563ef11907. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

