### PR TITLE
Enforce warning-level failure in R CMD check CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -128,10 +128,20 @@ jobs:
           rcmdcheck::rcmdcheck(
             args = c("--no-manual", "--as-cran", "--no-build-vignettes"),
             build_args = c("--no-build-vignettes"),
-            error_on = "error",
+            error_on = "warning",
             check_dir = "check"
           )
         shell: Rscript {0}
+
+      - name: Show R CMD check summary
+        if: always()
+        run: |
+          echo "R CMD check 00check.log locations:"
+          find check -name '00check.log' -print || true
+          echo
+          echo "Warnings/Errors/Notes from 00check.log:"
+          find check -name '00check.log' -exec grep -nE "WARNING|ERROR|NOTE" {} \; || true
+        shell: bash
 
       - name: Show testthat output
         if: always()
@@ -197,10 +207,20 @@ jobs:
           rcmdcheck::rcmdcheck(
             args = c("--no-manual", "--as-cran", "--no-build-vignettes"),
             build_args = c("--no-build-vignettes"),
-            error_on = "error",
+            error_on = "warning",
             check_dir = "check"
           )
         shell: Rscript {0}
+
+      - name: Show R CMD check summary
+        if: always()
+        run: |
+          echo "R CMD check 00check.log locations:"
+          find check -name '00check.log' -print || true
+          echo
+          echo "Warnings/Errors/Notes from 00check.log:"
+          find check -name '00check.log' -exec grep -nE "WARNING|ERROR|NOTE" {} \; || true
+        shell: bash
 
       - name: Show testthat output
         if: always()

--- a/tracker.json
+++ b/tracker.json
@@ -19,7 +19,7 @@
     {
       "title": "ci: enforce R CMD check --as-cran and fail on warnings",
       "description": "Tighten CI quality gates for release readiness.",
-      "status": "planned",
+      "status": "completed",
       "priority": "high",
       "labels": ["ci", "quality"]
     },


### PR DESCRIPTION
## Summary
- enforce warning-level CI failure for `R CMD check --as-cran` by setting `error_on = "warning"` in both check jobs
- add explicit `Show R CMD check summary` steps to surface WARNING/ERROR/NOTE lines directly in CI logs
- mark tracker task `ci: enforce R CMD check --as-cran and fail on warnings` as completed

## Notes
- workflow YAML parses successfully after changes

Closes #30

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail CI when R CMD check --as-cran emits warnings by setting `error_on = "warning"` in both jobs. Add a summary step in both jobs that prints `00check.log` locations and WARNING/ERROR/NOTE lines to CI logs for faster triage (closes #30).

<sup>Written for commit b622fd02365b31845838c1e595e28dad39d05ae9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

