### PR TITLE
Add edge-case tests for positivity and separation

### DIFF
--- a/tests/testthat/test-estimators.R
+++ b/tests/testthat/test-estimators.R
@@ -143,3 +143,57 @@ test_that("effect difference computed correctly for risk difference", {
   expected_diff <- result$estimates$observational - result$estimates$rct
   expect_equal(result$estimates$difference, expected_diff)
 })
+
+test_that("positivity-edge weights remain finite and nonnegative", {
+  set.seed(106)
+
+  n <- 400
+  A <- rbinom(n, 1, 0.5)
+  e <- c(
+    rep(1e-3, n / 4),
+    rep(0.999, n / 4),
+    rep(0.05, n / 4),
+    rep(0.95, n / 4)
+  )
+
+  ipw_weights <- effectbridge:::compute_ipw_weights(
+    A = A,
+    e = e,
+    weights = rep(1, n),
+    stabilize = FALSE
+  )
+
+  expect_true(all(is.finite(ipw_weights)))
+  expect_true(all(ipw_weights >= 0))
+  expect_gt(max(ipw_weights), 100)
+})
+
+test_that("perfect-separation-like propensity model falls back safely", {
+  set.seed(107)
+
+  n <- 300
+  X1 <- rnorm(n)
+  X2 <- rbinom(n, 1, 0.5)
+  A <- as.integer(X1 > 0) # deterministic treatment assignment (separation)
+  X <- cbind("(Intercept)" = 1, X1 = X1, X2 = X2)
+
+  expect_warning(
+    ps_fit <- effectbridge:::fit_propensity_model(A, X, weights = rep(1, n)),
+    "Propensity score model fitting failed; using marginal treated proportion as PS"
+  )
+  e <- ps_fit$fitted_values
+
+  expect_true(all(e >= 1e-3))
+  expect_true(all(e <= 1 - 1e-3))
+  expect_equal(mean(e), mean(A), tolerance = 1e-12)
+  expect_equal(stats::sd(e), 0, tolerance = 1e-12)
+
+  ipw_weights <- effectbridge:::compute_ipw_weights(
+    A = A,
+    e = e,
+    weights = rep(1, n),
+    stabilize = FALSE
+  )
+  expect_true(all(is.finite(ipw_weights)))
+  expect_true(all(ipw_weights >= 0))
+})

--- a/tracker.json
+++ b/tracker.json
@@ -26,7 +26,7 @@
     {
       "title": "test: add edge-case tests for positivity and perfect separation",
       "description": "Add focused tests for critical estimator failure modes.",
-      "status": "planned",
+      "status": "completed",
       "priority": "medium",
       "labels": ["testing", "estimators"]
     },


### PR DESCRIPTION
## Summary
- add focused estimator tests for positivity-edge and perfect-separation failure modes
- assert finite/nonnegative IPW weights under extreme propensity values
- assert safe fallback behavior when propensity model fitting fails under deterministic treatment assignment
- mark tracker task `test: add edge-case tests for positivity and perfect separation` as completed

## Validation
- ran: `Rscript -e "devtools::test(filter='estimators')"`
- result: 0 failures in estimator test context

Closes #31


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add edge-case estimator tests for positivity limits and perfect separation in `effectbridge`. They assert finite, nonnegative IPW weights at extreme propensity values and verify fallback to the marginal PS when fitting fails under deterministic treatment, closing #31.

<sup>Written for commit 96db29f0a228b4a272c7658cf2ed2cc65255914c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

